### PR TITLE
feat: implement data versioning and update rides history

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Snapp",
   "short_name": "My Snapp",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "Analyze your Snapp rides",
   "permissions": ["tabs", "storage"],
   "browser_action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snapp-analyzer-extension",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapp-analyzer-extension",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lintOnSave": true,
   "description": "Analyze your Snapp rides",
   "main": "index.js",

--- a/src/popup/src/api/index.ts
+++ b/src/popup/src/api/index.ts
@@ -1,6 +1,6 @@
 import type { RideHistoryResponse } from 'types/RideHistoryResponse';
 
-export const getRidePage = async (
+export const getSingleRidePage = async (
   accessToken: string,
   page: number
 ): Promise<RideHistoryResponse[]> => {

--- a/src/popup/src/containers/Result/Result.tsx
+++ b/src/popup/src/containers/Result/Result.tsx
@@ -14,19 +14,19 @@ import Summary from 'components/Summary';
 import styles from './Result.module.css';
 
 interface Props {
-  data: RidesData;
+  rides: RidesData;
   mapboxToken: string | undefined;
 }
 
-const Result = ({ mapboxToken, data }: Props) => {
+const Result = ({ mapboxToken, rides }: Props) => {
   const options = useMemo(
     () =>
-      Object.keys(data).sort((a, b) => {
+      Object.keys(rides).sort((a, b) => {
         return (
           data_pattern.indexOf(b as string) - data_pattern.indexOf(a as string)
         );
       }),
-    [data]
+    [rides]
   );
   const [year, setYear] = useState<ReactText>(options[0]);
 
@@ -41,12 +41,12 @@ const Result = ({ mapboxToken, data }: Props) => {
   );
 
   const getTotal = useMemo(() => {
-    const _years = Object.keys(data).reduce((tmp, year) => {
+    const _years = Object.keys(rides).reduce((tmp, year) => {
       if (year === 'total') {
         return tmp;
       }
 
-      const { _summary } = data[year] as Required<Rides>;
+      const { _summary } = rides[year] as Required<Rides>;
 
       // add _years chart
       setWith(tmp, [year], {
@@ -57,14 +57,14 @@ const Result = ({ mapboxToken, data }: Props) => {
       return tmp;
     }, {});
 
-    data['total']._years = _years;
+    rides['total']._years = _years;
 
-    return data['total'];
-  }, [data]);
+    return rides['total'];
+  }, [rides]);
 
   const currentData = useMemo(
-    () => (year === 'total' ? getTotal : data[year]),
-    [data, year, getTotal]
+    () => (year === 'total' ? getTotal : rides[year]),
+    [rides, year, getTotal]
   );
 
   return (

--- a/src/popup/src/containers/SnappExtension/SnappExtension.module.css
+++ b/src/popup/src/containers/SnappExtension/SnappExtension.module.css
@@ -39,3 +39,9 @@
   margin: 1rem 0;
   background-color: #00d16f;
 }
+
+.lastRideDate {
+  color: #777;
+  font-size: 0.9rem;
+  min-height: 1.375rem;
+}

--- a/src/popup/src/containers/SnappExtension/SnappExtension.tsx
+++ b/src/popup/src/containers/SnappExtension/SnappExtension.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-import type { RidesData } from 'types/Rides';
+import type { DataStorage } from 'types/Storage';
 import type { RideHistoryResponse } from 'types/RideHistoryResponse';
 
 import { convertedData } from 'manipulate';
 import { getErrorMessage } from 'utils/messages';
-import { getRidePage } from 'api';
+import { getSingleRidePage } from 'api';
 import constants from 'utils/constants';
+import { convertToLastVersion, getLastVersionNumber } from 'manipulate/convert';
 
 import Result from 'containers/Result';
 import CarAnimation from 'components/CarAnimation';
@@ -17,7 +18,7 @@ import styles from './SnappExtension.module.css';
 
 const SnappExtension = () => {
   const [accessToken, setAccessToken] = useState<string>('');
-  const [data, setData] = useState<RidesData | null>(null);
+  const [dataInStorage, setDataInStorage] = useState<DataStorage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -32,7 +33,7 @@ const SnappExtension = () => {
       setAccessToken(accessToken);
     });
     chrome.storage.local.get('result', ({ result }) => {
-      setData(result);
+      setDataInStorage(result);
     });
     chrome.storage.local.get('mapboxToken', ({ mapboxToken }) => {
       setMapboxToken(mapboxToken || '');
@@ -47,20 +48,47 @@ const SnappExtension = () => {
   }, []);
 
   // fetch data from Snapp API
-  const getRides = async (
+  const getAllRides = async (
     accessToken: string
   ): Promise<RideHistoryResponse[]> => {
     let page = 1;
     setPage(page);
-    let rides = await getRidePage(accessToken, page++);
+    let rides = await getSingleRidePage(accessToken, page++);
     let response = [...rides];
 
     while (rides.length > 0) {
       response = [...response, ...rides];
       setPage(page);
-      rides = await getRidePage(accessToken, page++);
+      rides = await getSingleRidePage(accessToken, page++);
     }
     return response;
+  };
+
+  const prepareRidesData = async (accessToken: string) => {
+    try {
+      const response = await getAllRides(accessToken);
+      const [lastRide] = response;
+      const rides = convertedData(response);
+
+      handleShowResult(
+        {
+          rides,
+          meta: {
+            lastRideId: lastRide.human_readable_id,
+            version: getLastVersionNumber(),
+            forceUpdate: false,
+          },
+        },
+        true
+      );
+    } catch (e) {
+      const error =
+        getErrorMessage[(e as Error).message] || constants.somethingWentWrong;
+      setError(error);
+      setIsLoading(false);
+      return;
+    }
+    setIsFetching(false);
   };
 
   const handleGetRidesHistory = async (
@@ -68,29 +96,31 @@ const SnappExtension = () => {
   ) => {
     e.preventDefault();
     setIsLoading(true);
-    if (data) {
-      handleShowResult(data, false);
-    } else {
-      if (e.target instanceof HTMLElement) {
-        try {
-          const accessToken = e.target.dataset.accessToken as string;
-          const response = await getRides(accessToken);
-          const result = convertedData(response);
-          handleShowResult(result, true);
-        } catch (e) {
-          const error =
-            getErrorMessage[(e as Error).message] ||
-            constants.somethingWentWrong;
-          setError(error);
-          setIsLoading(false);
-          return;
+    if (e.target instanceof HTMLElement) {
+      const accessToken = e.target.dataset.accessToken as string;
+
+      if (dataInStorage) {
+        const { meta, rides } = convertToLastVersion(dataInStorage);
+        if (meta.forceUpdate) {
+          prepareRidesData(accessToken);
+        } else {
+          // get last ride
+          const [lastRide] = await getSingleRidePage(accessToken, 1);
+          setPage(1);
+          const isUpdated = lastRide.human_readable_id === meta.lastRideId;
+          if (isUpdated) {
+            handleShowResult({ rides, meta }, false);
+          } else {
+            // TODO: get new rides
+          }
         }
+      } else {
+        prepareRidesData(accessToken);
       }
-      setIsFetching(false);
     }
   };
 
-  const handleShowResult = (result: RidesData, withLoading: boolean) => {
+  const handleShowResult = (result: DataStorage, withLoading: boolean) => {
     chrome.storage.local.set({ result }, () => {
       if (withLoading) {
         pendingTimer.current = setTimeout(() => {
@@ -115,8 +145,8 @@ const SnappExtension = () => {
   };
 
   if (window.location.href.includes('#result')) {
-    if (data) {
-      return <Result data={data} mapboxToken={mapboxToken} />;
+    if (dataInStorage) {
+      return <Result data={dataInStorage.rides} mapboxToken={mapboxToken} />;
     }
     return <div className={styles.loadData}>{constants.loadData}</div>;
   }

--- a/src/popup/src/containers/SnappExtension/SnappExtension.tsx
+++ b/src/popup/src/containers/SnappExtension/SnappExtension.tsx
@@ -146,7 +146,7 @@ const SnappExtension = () => {
 
   if (window.location.href.includes('#result')) {
     if (dataInStorage) {
-      return <Result data={dataInStorage.rides} mapboxToken={mapboxToken} />;
+      return <Result rides={dataInStorage.rides} mapboxToken={mapboxToken} />;
     }
     return <div className={styles.loadData}>{constants.loadData}</div>;
   }

--- a/src/popup/src/containers/SnappExtension/SnappExtension.tsx
+++ b/src/popup/src/containers/SnappExtension/SnappExtension.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
+import get from 'lodash.get';
 
 import type { DataStorage } from 'types/Storage';
 import type { RideHistoryResponse } from 'types/RideHistoryResponse';
 
 import { getReport, mergeReports } from 'manipulate';
-import { getErrorMessage } from 'utils/messages';
+import { getErrorMessage, getLastRideDateMessage } from 'utils/messages';
 import { getSingleRidePage } from 'api';
 import constants from 'utils/constants';
 import { convertToLastVersion, getLastVersionNumber } from 'manipulate/convert';
@@ -192,6 +193,8 @@ const SnappExtension = () => {
     return <CarAnimation isFetching={isFetching} speed={page} />;
   }
 
+  const lastRideEndRange = get(dataInStorage, 'rides.total._ranges.end', '');
+
   return (
     <main className={styles.extension}>
       <div className={styles.actions}>
@@ -231,6 +234,9 @@ const SnappExtension = () => {
             >
               {constants.getAnalytics}
             </button>
+            <span className={styles.lastRideDate}>
+              {lastRideEndRange && getLastRideDateMessage(lastRideEndRange)}
+            </span>
           </>
         ) : (
           <>

--- a/src/popup/src/index.css
+++ b/src/popup/src/index.css
@@ -7,7 +7,7 @@ body {
   font-size: 1rem;
   justify-content: center;
   margin: 0;
-  min-height: 20rem;
+  min-height: 23rem;
   text-align: center;
   user-select: none;
 }

--- a/src/popup/src/manipulate/convert.ts
+++ b/src/popup/src/manipulate/convert.ts
@@ -1,0 +1,67 @@
+import { RidesData } from 'types/Rides';
+import {
+  DataStorage,
+  VersionObject,
+  VersionsKeys,
+  DATA_VERSIONS,
+  MetaData,
+} from 'types/Storage';
+
+const convertFunctions: {
+  [version in VersionsKeys]: VersionObject;
+} = {
+  '1': { forceUpdate: true },
+};
+
+export const getLastVersionNumber = () =>
+  DATA_VERSIONS[DATA_VERSIONS.length - 1];
+
+export const convertToLastVersion = (data: DataStorage) => {
+  const hasVersion = !!(data as DataStorage)?.meta?.version;
+
+  // get available versions
+  const versions = Object.keys(convertFunctions);
+
+  const newRides = versions.reduce(
+    (tmp: DataStorage, version, index) => {
+      const { forceUpdate } = convertFunctions[version];
+
+      const meta: MetaData = {
+        version,
+        forceUpdate,
+        lastRideId: data?.meta?.lastRideId || '',
+      };
+
+      // init version
+      if (!hasVersion) {
+        tmp.rides = (data as unknown) as RidesData;
+        tmp.meta = meta;
+        return tmp;
+      }
+
+      // apply new version changes
+      if (Number(data.meta.version) < Number(version)) {
+        tmp.rides = { ...tmp.rides };
+        tmp.meta = meta;
+        return tmp;
+      }
+
+      // check an invalid version
+      if (index + 1 === versions.length) {
+        const isInvalidVersion = versions.some((v) => data.meta.version !== v);
+        if (isInvalidVersion) {
+          data.meta.version = version;
+        }
+      }
+
+      // no changes required
+      data.meta.forceUpdate = false;
+      return data as DataStorage;
+    },
+    {
+      rides: {},
+      meta: { version: '1', lastRideId: '', forceUpdate: false },
+    }
+  );
+  return newRides;
+};

--- a/src/popup/src/types/RideHistoryResponse.ts
+++ b/src/popup/src/types/RideHistoryResponse.ts
@@ -9,6 +9,7 @@ interface RowDetail {
 export interface RideHistoryResponse {
   // estimated_distance: number; /* deprecated ¯\_(ツ)_/¯ */
   // real_duration: number; /* deprecated ¯\_(ツ)_/¯ */
+  human_readable_id: string;
   created_at: string;
   destination: Coordinate;
   final_price: number;

--- a/src/popup/src/types/Storage.ts
+++ b/src/popup/src/types/Storage.ts
@@ -1,0 +1,20 @@
+import type { ArrayElement } from './helpers';
+import type { RidesData } from './Rides';
+
+export const DATA_VERSIONS = ['1'] as const;
+
+export type VersionsKeys = ArrayElement<typeof DATA_VERSIONS>;
+
+export type VersionObject = {
+  forceUpdate: boolean;
+};
+
+export type MetaData = {
+  lastRideId: string;
+  version: VersionsKeys;
+} & Pick<VersionObject, 'forceUpdate'>;
+
+export type DataStorage = {
+  rides: RidesData;
+  meta: MetaData;
+};

--- a/src/popup/src/types/helpers.ts
+++ b/src/popup/src/types/helpers.ts
@@ -8,3 +8,5 @@ export type PickByValue<T, ValueType> = Pick<
       : never;
   }[keyof T]
 >;
+
+export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;

--- a/src/popup/src/utils/messages.ts
+++ b/src/popup/src/utils/messages.ts
@@ -139,3 +139,7 @@ export const getExportName: { [type in BarChartTypes]: string } = {
 export const getErrorMessage: { [statusCode: string]: string } = {
   401: 'خیلی وقته بهم سر نزدی! باید دوباره وارد حساب اسنپت بشی.',
 };
+
+export const getLastRideDateMessage = (lastEndRange: string) => {
+  return `تاریخ آخرین سفر: ${lastEndRange}`;
+};


### PR DESCRIPTION
### [ADD]
- add data versioning
- update rides history based on last ride id
- show average rides score in summary info

### [IMPROVE]
- show last ride date in popup

### [NOTE]
In this version, we have metadata with required data for manipulating the stored data in extension.

- **lastRideId:** store last `human_readable_id` from fetched data 
- **version:** specific version for each data
- **forceUpdate:** request all data
